### PR TITLE
Remove time element of organiser

### DIFF
--- a/organizer.py
+++ b/organizer.py
@@ -1,8 +1,6 @@
 import os
-import time
 
 from guessit import guessit
-from datetime import datetime
 
 finished_files = []
 
@@ -64,13 +62,5 @@ def renamer():
             os.rename(file, titleInformation(file))
             finished_files.append(titleInformation(file))
 
-def checkTime():
-    now = datetime.now().time()
-    if now.hour == 24:
-        return True
-    return False
-
 if __name__ == "__main__":
-    while True:
-        if checkTime():
-            renamer()
+    renamer()


### PR DESCRIPTION
Just a fork that makes the algorithm run whenever the user wants to, not at midnight. Minor change, but could be useful. Please keep this separate from the main, unless you want to abandon the midnight system.